### PR TITLE
findResource 这个函数没有正确处理name 中带有文件名后缀的情况

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,12 @@ function findResource(name, path) {
   var info = fis.uri(name, path);
 
   for (var i = 0, len = extList.length; i < len && !info.file; i++) {
-    info = fis.uri(name + extList[i], path);
+    if (name.indexOf(extList[i]) > 0) {
+      info = fis.uri(name.slice(0, -extList[i].length) + extList[i], path);
+    } else {
+      info = fis.uri(name + extList[i], path);  
+    }
+    
   }
 
   return info;


### PR DESCRIPTION
findResource 这个函数没有正确处理name 中带有文件名后缀的情况
